### PR TITLE
Add deployed field with capture variable, multiple networks

### DIFF
--- a/declarativeDeployment.yaml
+++ b/declarativeDeployment.yaml
@@ -2,7 +2,7 @@ version: 0.0.1
 description: declarative deployment file "declarative deployments for Truffle projects
 # put npm packages needed for deployment here
 require: ["dotenv"]
-# organize by network, then by
+# organize by network, then by contract
 deployed:
   mainnet:
     SafeMathLib:


### PR DESCRIPTION
This PR adds a `deployed` element to our `yaml` file, organized by network. 

A couple of other features included here: 
- versioning and description
- require declaration for any npm packages that may need to be imported
- linked contracts
- arguments for deploying each contract: these are positional, curious if people disagree on this 
- capture variables and the flow related to that (ifTrue, variable transformation, etc.)